### PR TITLE
[GH-1] update build script for browser folder to use a relative import statement for script base folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ As you can see, this library depends on the `@phaserjs/editor-scripts-base` libr
 
 * Get the files in the [browser](./browser/) folder and copy them into your JavaScript project. It includes Phaser Editor files and JavaScript files.
 
+**Note:** Since this project has a dependency on the `@phaserjs/editor-scripts-base` library, the generated `phaserjs_editor_scripts_quick` folder must be placed next to the `phaserjs_editor_scripts_base` folder in order for the relative imports to resolve properly.
+
 ## Summary
 
 The scripts split in groups:
@@ -141,7 +143,7 @@ You can create variants of the **RootScript** and use different keys.
 
 ### On General Event
 
-An event script node. It registers to the given `eventEmitter` and listens to the given `eventName``. When the event is fired, it executes the children's action nodes. 
+An event script node. It registers to the given `eventEmitter` and listens to the given `eventName``. When the event is fired, it executes the children's action nodes.
 
 You can create handy prefab variants for different events, like the **On Pointer Down Event** prefab.
 
@@ -229,25 +231,25 @@ This action allows the **Action Target Config** component.
 
 ### Set Angle Action
 
-An action to set the given **Angle** to the game object. 
+An action to set the given **Angle** to the game object.
 
 This action allows the **Action Target Config** component.
 
 ### Set Scale X/Y Action
 
-An action to set the given **X** or **Y** to the game object. 
+An action to set the given **X** or **Y** to the game object.
 
 This action allows the **Action Target Config** component.
 
 ### Set Flip Action
 
-An action to set flip the game object. It looks into the **Flip Vertical** and **Flip Horizontal** properties. 
+An action to set flip the game object. It looks into the **Flip Vertical** and **Flip Horizontal** properties.
 
 This action allows the **Action Target Config** component.
 
 ### Spawn Object Action
 
-This action creates an instance of the given **Object Prefab** and adds it to the world. If the **Spawn In Parent Position** parameter is checked, then it sets the position of the new object to the same position as the script's game object. 
+This action creates an instance of the given **Object Prefab** and adds it to the world. If the **Spawn In Parent Position** parameter is checked, then it sets the position of the new object to the same position as the script's game object.
 
 Finally, it executes the children nodes and passes the new object as the first argument.
 
@@ -270,7 +272,7 @@ The actions:
 * **Make Object Collider Action** - Creates a physics collider with the game object.
 * **Set Body Enable Action** - To enable/disable physics in the game object.
 * **Start Flip With Velocity Action** - Starts flipping the game object heading to the velocity vector.
-* **Start Follow Pointer Action** - Starts moving the game object toward the pointer position. 
+* **Start Follow Pointer Action** - Starts moving the game object toward the pointer position.
 * **If Body Touching** - A conditional action to test if the body touching state.
 
 The base classes:
@@ -402,7 +404,7 @@ When the animation completes, the script executes the children's scripts.
 
 This action allows the **Action Target Config** user component.
 
-### Push Action 
+### Push Action
 
 *Class: `PushActionScript`*
 
@@ -523,7 +525,7 @@ You can configure the duration of the effect by adding the [Duration Config](htt
 
 This action runs the [Flash effect](https://newdocs.phaser.io/docs/3.70.0/focus/Phaser.Cameras.Scene2D.Camera-flash) of the camera.
 
-You can tweak the effect by setting the **Color** property. 
+You can tweak the effect by setting the **Color** property.
 
 You can configure the duration of the effect by adding the [Duration Config](https://github.com/PhaserEditor2D/phasereditor2d-scripts-simple-animations#duration-config) component of the `@phaserjs/editor-scripts-simple-animations` library.
 
@@ -533,7 +535,7 @@ You can configure the duration of the effect by adding the [Duration Config](htt
 
 This action runs the [Fade effect](https://newdocs.phaser.io/docs/3.70.0/focus/Phaser.Cameras.Scene2D.Camera-fade) of the camera.
 
-You can tweak the effect by setting the **Color** and **Fade Direction** properties. 
+You can tweak the effect by setting the **Color** and **Fade Direction** properties.
 
 You can configure the duration of the effect by adding the [Duration Config](https://github.com/PhaserEditor2D/phasereditor2d-scripts-simple-animations#duration-config) component of the `@phaserjs/editor-scripts-simple-animations` library.
 
@@ -574,7 +576,7 @@ The configuration components:
 
 This action sets a random X value to the game object. It requires that you add to this node one of the random configuration components.
 
-It allows 
+It allows
 
 ### Set Random Y Action
 
@@ -598,7 +600,7 @@ This user component contains the parameters for picking a random number from an 
 
 ## Timer Group
 
-This library provides a few actions for implementing timers in your game. 
+This library provides a few actions for implementing timers in your game.
 
 As a reminder, an action is executed by an event script or another action.
 

--- a/browser/phaserjs_editor_scripts_quick/animations/FadeActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/FadeActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 import EaseConfigComp from "./EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/animations/MoveInSceneActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/MoveInSceneActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 import EaseConfigComp from "./EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/animations/MoveOutSceneActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/MoveOutSceneActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 import EaseConfigComp from "./EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/animations/PushActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/animations/PushActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "./DurationConfigComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/arcade/GetGameObjectFromBodyActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/GetGameObjectFromBodyActionScript.js
@@ -1,7 +1,7 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
-import { ActionTargetComp } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
+import { ActionTargetComp } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class GetGameObjectFromBodyActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/IfBodyTouchingScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/IfBodyTouchingScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 import ExecChildrenActionScript from "../core/ExecChildrenActionScript.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/arcade/MakeObjectColliderActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/MakeObjectColliderActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class MakeObjectColliderActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetBodyEnableActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetBodyEnableActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetBodyEnableActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetVelocityActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetVelocityXActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/SetVelocityYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SetVelocityYActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/StartFlipWithVelocityAction.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/StartFlipWithVelocityAction.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StartFlipWithVelocityAction extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/arcade/StartFollowPointerActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/arcade/StartFollowPointerActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StartFollowPointerActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/AudioPauseAllActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/AudioPauseAllActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class AudioPauseAllActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/PlaySoundActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/PlaySoundActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AudioLoopConfigComp from "./AudioLoopConfigComp.js";
 import AudioVolumeConfigComp from "./AudioVolumeConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/audio/ResumeAllAudioActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/ResumeAllAudioActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ResumeAllAudioActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/StopAllSoundsActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/StopAllSoundsActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StopAllSoundsActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/audio/StopSoundActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/audio/StopSoundActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StopSoundActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/camera/CameraStartFollowActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/CameraStartFollowActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class CameraStartFollowActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/camera/CameraStopFollowActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/CameraStopFollowActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class CameraStopFollowActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/camera/FadeCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/FadeCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "../animations/DurationConfigComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/camera/FlashCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/FlashCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import FadeCameraActionScript from "./FadeCameraActionScript.js";
 import DurationConfigComp from "../animations/DurationConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/camera/ShakeCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/ShakeCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "../animations/DurationConfigComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/camera/ZoomCameraActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/camera/ZoomCameraActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import DurationConfigComp from "../animations/DurationConfigComp.js";
 import EaseConfigComp from "../animations/EaseConfigComp.js";

--- a/browser/phaserjs_editor_scripts_quick/core/AddToParentActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/AddToParentActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class AddToParentActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/AlertActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/AlertActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class AlertActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/CallbackActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/CallbackActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class CallbackActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ConsoleLogActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ConsoleLogActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ConsoleLogActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/DestroyActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/DestroyActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class DestroyActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/EmitEventActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/EmitEventActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class EmitEventActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ExecActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ExecActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ExecActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ExecChildrenActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ExecChildrenActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ExecChildrenActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/ExecRandomActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/ExecRandomActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class ExecRandomActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/FlipActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/FlipActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class FlipActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/OnAwakeScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/OnAwakeScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class OnAwakeScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/OnEventScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/OnEventScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class OnEventScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/PlaySpriteAnimationActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/PlaySpriteAnimationActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class PlaySpriteAnimationActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/RootScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/RootScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class RootScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/SetAngleActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetAngleActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetScaleXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetScaleXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetScaleYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetScaleYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SetYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SetYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import AssignOpComp from "./AssignOpComp.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/core/SpawnActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SpawnActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SpawnActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/SpriteScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/SpriteScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class SpriteScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/core/StartSceneActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/core/StartSceneActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class StartSceneActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/random/SetRandomXActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/random/SetRandomXActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "./GetRandom.js";
 import AssignOpComp from "../core/AssignOpComp.js";

--- a/browser/phaserjs_editor_scripts_quick/random/SetRandomYActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/random/SetRandomYActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "./GetRandom.js";
 import AssignOpComp from "../core/AssignOpComp.js";

--- a/browser/phaserjs_editor_scripts_quick/timer/DelayActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/DelayActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class DelayActionScript extends ScriptNode {

--- a/browser/phaserjs_editor_scripts_quick/timer/DelayRandomActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/DelayRandomActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "../random/GetRandom.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/timer/EmitRandomTickActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/EmitRandomTickActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 import GetRandom from "../random/GetRandom.js";
 /* END-USER-IMPORTS */

--- a/browser/phaserjs_editor_scripts_quick/timer/EmitTickActionScript.js
+++ b/browser/phaserjs_editor_scripts_quick/timer/EmitTickActionScript.js
@@ -1,6 +1,6 @@
 // You can write more code here
 /* START OF COMPILED CODE */
-import { ScriptNode } from "@phaserjs/editor-scripts-base.js";
+import { ScriptNode } from "../../phaserjs_editor_scripts_base/index.js";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 export default class EmitTickActionScript extends ScriptNode {

--- a/build-browser.js
+++ b/build-browser.js
@@ -56,6 +56,9 @@ function processJSFiles(fromFolder, toFolder) {
 			const importRegex = /from "([^"]+)"/g;
 
 			content = content.replace(importRegex, (match, p1) => {
+				if (p1 === '@phaserjs/editor-scripts-base') {
+					return `from "../../phaserjs_editor_scripts_base/index.js"`;
+				}
 				return `from "${p1}.js"`;
 			});
 


### PR DESCRIPTION
Updated the build script to check if the `import` line for a file is referencing the editor scripts base package, and when there is a match the `import` statement will be changed from:

```js
from "@phaserjs/editor-scripts-base.js";
```

to

```js
from "../../phaserjs_editor_scripts_base/index.js";
```

This fix has a few limitations:

* if any other npm packages are added to this library, this change will not fix those
* the generated `phaserjs_editor_scripts_quick` needs to be placed next to the `phaserjs_editor_scripts_base` folder.

Added a note to the readme file about the placement of the folder.

Most of the file changes in the MR are the newly generated `browser` files that use the updated `import` statement.

Relates to https://github.com/phaserjs/editor-scripts-quick/issues/1